### PR TITLE
New parameter publish_dir_mode_fastq 

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The nf-core/fetchfastq pipeline comes with documentation about the pipeline [usa
 
 ## Credits
 
-nf-core/fetchfastq was originally written by Harshil Patel ([@drpatelh](https://github.com/drpatelh)) from [The Bioinformatics & Biostatistics Group](https://www.crick.ac.uk/research/science-technology-platforms/bioinformatics-and-biostatistics/) at [The Francis Crick Institute, London](https://www.crick.ac.uk/) and Jose Espinosa-Carrasco ([@JoseEspinosa](https://github.com/JoseEspinosa)) from [The Bioinformatics & Genomics Group](https://www.crg.eu/en/cedric_notredame) at [The Centre for Genomic Regulation, Spain](https://www.crg.eu/).
+nf-core/fetchfastq was originally written by Harshil Patel ([@drpatelh](https://github.com/drpatelh)) from [The Bioinformatics & Biostatistics Group](https://www.crick.ac.uk/research/science-technology-platforms/bioinformatics-and-biostatistics/) at [The Francis Crick Institute, London](https://www.crick.ac.uk/) and Jose Espinosa-Carrasco ([@JoseEspinosa](https://github.com/JoseEspinosa)) from [The Comparative Bioinformatics Group](https://www.crg.eu/en/cedric_notredame) at [The Centre for Genomic Regulation, Spain](https://www.crg.eu/).
 
 ## Contributions and Support
 

--- a/modules/local/sra_fastq_ftp.nf
+++ b/modules/local/sra_fastq_ftp.nf
@@ -9,7 +9,7 @@ process SRA_FASTQ_FTP {
     label 'process_medium'
     label 'error_retry'
     publishDir "${params.outdir}",
-        mode: params.publish_dir_mode,
+        mode: params.publish_dir_mode_fastq,
         saveAs: { filename -> saveFiles(filename:filename, options:params.options, publish_dir:getSoftwareName(task.process), meta:meta, publish_by_meta:['id']) }
 
     conda (params.enable_conda ? "conda-forge::sed=4.7" : null)

--- a/nextflow.config
+++ b/nextflow.config
@@ -19,6 +19,7 @@ params {
     outdir                     = './results'
     tracedir                   = "${params.outdir}/pipeline_info"
     publish_dir_mode           = 'copy'
+    publish_dir_mode_fastq     = 'move'
     email                      = null
     email_on_fail              = null
     plaintext_email            = false


### PR DESCRIPTION
The parameter `publish_dir_mode_fastq` should allow to independently set the mode for the publication of the `fastq` files. The problem is that using `copy` doubles up on the storage space since the `fastq` files are duplicated.

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [ ] If you've fixed a bug or added code that should be tested, add tests!
    - [ ] If you've added a new tool - have you followed the pipeline conventions in the [contribution docs](https://github.com/nf-core/fetchfastq/tree/master/.github/CONTRIBUTING.md)
    - [ ] If necessary, also make a PR on the nf-core/fetchfastq _branch_ on the [nf-core/test-datasets](https://github.com/nf-core/test-datasets) repository.
- [ ] Make sure your code lints (`nf-core lint .`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker`).
- [ ] Usage Documentation in `docs/usage.md` is updated.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
